### PR TITLE
Convert mainnet to testnet addresses

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3062,6 +3062,9 @@ function addressConvert(network: Object, args: Array<string>) {
   let version;
   let b58addr;
   let c32addr;
+  let testnetb58addr;
+  let testnetc32addr;
+
   if (addr.match(STACKS_ADDRESS_PATTERN)) {
     c32addr = addr;
     b58addr = c32check.c32ToB58(c32addr);
@@ -3074,7 +3077,28 @@ function addressConvert(network: Object, args: Array<string>) {
     throw new Error(`Unrecognized address ${addr}`);
   }
 
-  return Promise.resolve().then(() => JSONStringify({STACKS: c32addr, BTC: b58addr}));
+  if (network.isTestnet()) {
+    testnetb58addr = network.coerceAddress(b58addr);
+    testnetc32addr = c32check.b58ToC32(testnetb58addr);
+  }
+
+  return Promise.resolve().then(() => {
+    const result = {
+      mainnet: {
+        STACKS: c32addr, 
+        BTC: b58addr
+      }
+    };
+
+    if (network.isTestnet()) {
+      result.testnet = {
+        STACKS: testnetc32addr, 
+        BTC: testnetb58addr
+      };
+    }
+
+    return JSONStringify(result)
+  })
 }
 
 /*


### PR DESCRIPTION
`convert_address` will convert to testnet addresses if `-t` option is enabled
```
$ blockstack-cli -t convert_address SP29AN64DQX85QYQPFDKEGJVQB9CCS2A27344NQH9
{
  "mainnet": {
    "STACKS": "SP29AN64DQX85QYQPFDKEGJVQB9CCS2A27344NQH9",
    "BTC": "1ENW2Dhx9UkAPS9HTHQFbA8FKDCCNdxMrw"
  },
  "testnet": {
    "STACKS": "ST29AN64DQX85QYQPFDKEGJVQB9CCS2A2717ASTKW",
    "BTC": "mttTKGnvxWBRAYcuArNdR5LaBCnuD7pt7Y"
  }
}
```