### PR TITLE
Hotfix for flow build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
     "fetch-mock": "^5.5.0",
-    "flow-bin": "^0.49.1",
+    "flow-bin": "^0.66.0",
     "mock-local-storage": "^1.0.5",
     "nock": "^9.1.6",
     "node-fetch": "^2.1.2",

--- a/src/argparse.js
+++ b/src/argparse.js
@@ -2437,10 +2437,13 @@ export function makeAllCommandsHelp(): string {
 /*
  * Make a usage string for a single command
  */
-export function makeCommandUsageString(command: string) : string {
+export function makeCommandUsageString(command: ?string) : string {
   let res = "";
   if (command === 'all') {
     return makeAllCommandsHelp();
+  }
+  if (!command) {
+    return makeAllCommandsList();
   }
 
   const commandInfo = CLI_ARGS.properties[command];
@@ -2675,7 +2678,7 @@ export function getCommandArgs(command: string, argsList: Array<string>) {
 type checkArgsSuccessType = {
   'success': true,
   'command': string,
-  'args': Array<string>
+  'args': Array<?string>
 };
 
 type checkArgsFailType = {


### PR DESCRIPTION
This:

* Sets the correct flow version for npm
* Fixes what looks like a type error in the getCommandArgs (entries in args can be set to `null`)