### PR TITLE
Add get_did_configuration

### DIFF
--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -2301,6 +2301,9 @@ export const CLI_ARGS = {
       'The DID configuration should be placed in the json file ".well_known/did_configuration"' +
       '\n'+
       'Example:\n'+
+      '\n'+
+      '    $ # Tip: you can get your owner keys from your 12-word backup phrase using the get_owner_keys command.\n' +
+      '    $ export PRIVATE_OWNER_KEY="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"\n' +
       '    $ blockstack-cli get_did_configuration public_profile_for_testing.id.blockstack helloblockstack.com PRIVATE_OWNER_KEY\n' +
       '    {\n' +
       '       "entries": [\n'+

--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -2271,6 +2271,33 @@ export const CLI_ARGS = {
       '    ]\n' +
       '\n',
       group: 'Peer Services'
+    },
+    get_did_configuration: {
+      type: 'array',
+      items: [
+        {
+          name: 'blockstack_id',
+          type: 'string',
+          realtype: 'blockstack_id',
+          pattern: NAME_PATTERN + '|'+ SUBDOMAIN_PATTERN
+        },
+        {
+          name: 'domain',
+          type: 'string',
+          realtype: 'domain',
+          pattern: NAME_PATTERN + '|'+ SUBDOMAIN_PATTERN
+        },
+        {
+          name: 'owner_key',
+          type: 'string',
+          realtype: 'private_key',
+          pattern: `${PRIVATE_KEY_PATTERN_ANY}`
+        },
+      ],
+      minItems: 3,
+      maxItems: 3,
+      help: 'Creates a DID configuration for the given blockstack id and domain',
+      group: 'DID'
     }
   } as CLI_PROP,
   additionalProperties: false,

--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -2291,12 +2291,39 @@ export const CLI_ARGS = {
           name: 'owner_key',
           type: 'string',
           realtype: 'private_key',
-          pattern: `${PRIVATE_KEY_PATTERN_ANY}`
+          pattern: `${PRIVATE_KEY_PATTERN}`
         },
       ],
       minItems: 3,
       maxItems: 3,
-      help: 'Creates a DID configuration for the given blockstack id and domain',
+      help: 'Creates a DID configuration for the given blockstack id and domain to create a link between both.' +
+      'The specification is define by the Decentralized Identity Foundation at https://identity.foundation/specs/did-configuration/\n' +
+      'The DID configuration should be placed in the json file ".well_known/did_configuration"' +
+      '\n'+
+      'Example:\n'+
+      '    $ blockstack-cli get_did_configuration public_profile_for_testing.id.blockstack helloblockstack.com PRIVATE_OWNER_KEY\n' +
+      '    {\n' +
+      '       "entries": [\n'+
+      '          {\n' +
+      '            "did": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",\n' +
+      '            "jwt": "eyJ0eXAiOiJKV1QiL...."\n' +
+      '          }\n'+
+      '       ]\n'+
+      '    }\n'+
+      '\n'+
+      'The decoded content of the jwt above is \n'+
+      '    {\n'+
+      '       "header": {\n' +
+      '          "typ": "JWT", "alg": "ES256K"\n' +
+      '       },\n'+
+      '       "payload": {\n' +
+      '           "iss": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",\n' +
+      '           "domain": "helloblockstack.com",\n' +
+      '           "exp": "2020-12-07T13:05:28.375Z"\n' +
+      '       },\n'+
+      '       "signature": "NDY7ISzgAHKcZDvbxzTxQdVnf6xWMZ46w5vHcDpNx_1Fsyip0M6E6GMq_2YZ-gUcwmwlo8Ag9jgnfOkaBIFpoQ"\n' +
+      '    }\n' +
+      '\n',
       group: 'DID'
     }
   } as CLI_PROP,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2695,7 +2695,7 @@ function getKeyAddress(network: CLINetworkAdapter, args: string[]) : Promise<str
 function getDidConfiguration(network: CLINetworkAdapter, args: string[]) : Promise<string> {
   const privateKey = decodePrivateKey(args[2]);
   return makeDIDConfiguration(network, args[0], args[1], args[2]).then(didConfiguration => {
-    return JSONStringify(didConfiguration).toString()
+    return JSONStringify(didConfiguration)
   })
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,8 @@ import {
   IDAppKeys,
   getIDAppKeys,
   hasKeys,
-  UTXO
+  UTXO,
+  makeDIDConfiguration
 } from './utils';
 
 import {
@@ -2691,6 +2692,12 @@ function getKeyAddress(network: CLINetworkAdapter, args: string[]) : Promise<str
   });
 }
 
+function getDidConfiguration(network: CLINetworkAdapter, args: string[]) : Promise<string> {
+  const privateKey = decodePrivateKey(args[2]);
+  return makeDIDConfiguration(network, args[0], args[1], args[2]).then(didConfiguration => {
+    return JSONStringify(didConfiguration).toString()
+  })
+}
 
 /*
  * Get a file from Gaia.
@@ -3369,6 +3376,7 @@ const COMMANDS : Record<string, CommandFunction> = {
   'get_blockchain_record': getNameBlockchainRecord,
   'get_blockchain_history': getNameHistoryRecord,
   'get_confirmations': getConfirmations,
+  'get_did_configuration': getDidConfiguration,
   'get_namespace_blockchain_record': getNamespaceBlockchainRecord,
   'get_app_keys': getAppKeys,
   'get_owner_keys': getOwnerKeys,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import * as readline from 'readline';
 import * as stream from 'stream';
 import * as fs from 'fs';
 import * as blockstack from 'blockstack';
+import { decodeToken, SECP256K1Client, TokenSigner, TokenVerifier } from 'jsontokens'
 
 const ZoneFile = require('zone-file');
 
@@ -451,9 +452,30 @@ export function makeProfileJWT(profileData: Object, privateKey: string) : string
   const signedToken = blockstack.signProfileToken(profileData, privateKey);
   const wrappedToken = blockstack.wrapProfileToken(signedToken);
   const tokenRecords = [wrappedToken];
-  return JSONStringify(tokenRecords);
+  return JSON.stringify(tokenRecords);
 }
 
+export async function makeDIDConfiguration(network:CLINetworkAdapter, blockstackID: string, domain: String, privateKey:string): Promise<{did:string, jwt:string}> {
+
+  const tokenSigner = new TokenSigner("ES256K", privateKey)
+  const nameInfo = await network.getNameInfo(blockstackID);
+  const did = `did:btcr:${nameInfo.address}`
+  const payload = {
+    iss: did,
+    domain,
+    exp: new Date(
+      new Date().setFullYear(
+        new Date().getFullYear() + 1
+      )
+    )
+  }
+
+  const jwt = tokenSigner.sign(payload)
+  return {
+    did,
+    jwt
+  }
+}
 /*
  * Broadcast a transaction and a zone file.
  * Returns an object that encodes the success/failure of doing so.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -452,7 +452,7 @@ export function makeProfileJWT(profileData: Object, privateKey: string) : string
   const signedToken = blockstack.signProfileToken(profileData, privateKey);
   const wrappedToken = blockstack.wrapProfileToken(signedToken);
   const tokenRecords = [wrappedToken];
-  return JSON.stringify(tokenRecords);
+  return JSONStringify(tokenRecords);
 }
 
 export async function makeDIDConfiguration(network:CLINetworkAdapter, blockstackID: string, domain: string, privateKey:string): Promise<{entries:{did:string, jwt:string}[]}> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -455,11 +455,11 @@ export function makeProfileJWT(profileData: Object, privateKey: string) : string
   return JSON.stringify(tokenRecords);
 }
 
-export async function makeDIDConfiguration(network:CLINetworkAdapter, blockstackID: string, domain: String, privateKey:string): Promise<{did:string, jwt:string}> {
+export async function makeDIDConfiguration(network:CLINetworkAdapter, blockstackID: string, domain: string, privateKey:string): Promise<{entries:{did:string, jwt:string}[]}> {
 
   const tokenSigner = new TokenSigner("ES256K", privateKey)
   const nameInfo = await network.getNameInfo(blockstackID);
-  const did = `did:btcr:${nameInfo.address}`
+  const did = nameInfo.did
   const payload = {
     iss: did,
     domain,
@@ -471,10 +471,12 @@ export async function makeDIDConfiguration(network:CLINetworkAdapter, blockstack
   }
 
   const jwt = tokenSigner.sign(payload)
-  return {
-    did,
-    jwt
-  }
+  return {"entries": [
+    {
+      did,
+      jwt
+    }
+  ]}
 }
 /*
  * Broadcast a transaction and a zone file.


### PR DESCRIPTION
This PR 
* adds a method `get_did_configuration` that can be used to create a DID configuration as specified at https://identity.foundation/specs/did-configuration/
* fixes #29 