### PR TITLE
add method get_payment_key_24

### DIFF
--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -1053,6 +1053,37 @@ export const CLI_ARGS = {
       '\n',
       group: 'Key Management'
     },
+    get_payment_key_24: {
+      type: 'array',
+      items: [
+        {
+          name: 'backup_phrase',
+          type: 'string',
+          realtype: '24_words_or_ciphertext'
+        }
+      ],
+      minItems: 1,
+      maxItems: 1,
+      help: 'Get the payment private key from a 24-word backup phrase.  If you provide an ' +
+      'encrypted backup phrase, you will be asked for your password to decrypt it.  This command ' +
+      'will tell you your Bitcoin and Stacks token addresses as well.\n' +
+      '\n' +
+      'Example\n' +
+      '\n' +
+      '    $ blockstack-cli get_payment_key_24 "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"\n' +
+      '    [\n' +
+      '      {\n' +
+      '        "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",\n' +
+      '        "address": {\n' +
+      '          "BTC": "1ATAW6TAbTCKgU3xPgAcWQwjW9Q26Eambx",\n' +
+      '          "STACKS": "SP1KTQR7CTQNA20SV2VNTF9YABMR6RJERSES3KC6Z"\n' +
+      '        },\n' +
+      '        "index": 0\n' +
+      '      }\n' +
+      '    ]\n' +
+      '\n',
+      group: 'Key Management'
+    },
     get_zonefile: {
       type: 'array',
       items: [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ import {
 import {
   getOwnerKeyInfo,
   getPaymentKeyInfo,
+  getPaymentKeyInfo24,
   getApplicationKeyInfo,
   extractAppKey,
   STRENGTH,
@@ -2333,6 +2334,20 @@ async function getPaymentKey(network: CLINetworkAdapter, args: string[]) : Promi
 }
 
 /*
+ * Get the payment private key from a backup phrase
+ * args:
+ * @mnemonic (string) the 24-word phrase
+ */
+async function getPaymentKey24(network: CLINetworkAdapter, args: string[]) : Promise<string> {
+  const mnemonic = await getBackupPhrase(args[0]);
+  // keep the return value consistent with getOwnerKeys
+  const keyObj = await getPaymentKeyInfo24(network, mnemonic);
+  const keyInfo: PaymentKeyInfoType[] = [];
+  keyInfo.push(keyObj);
+  return JSONStringify(keyInfo);
+}
+
+/*
  * Make a private key and output it 
  * args:
  * @mnemonic (string) OPTIONAL; the 12-word phrase
@@ -3381,6 +3396,7 @@ const COMMANDS : Record<string, CommandFunction> = {
   'get_app_keys': getAppKeys,
   'get_owner_keys': getOwnerKeys,
   'get_payment_key': getPaymentKey,
+  'get_payment_key_24': getPaymentKey24,
   'get_zonefile': getZonefile,
   'lookup': lookup,
   'make_keychain': makeKeychain,

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -115,6 +115,34 @@ export async function getPaymentKeyInfo(network: CLINetworkAdapter, mnemonic : s
 }
 
 /*
+ * Get the payment key information for a 24-word phrase.
+ * @network (object) the blockstack network
+ * @mnemonic (string) the 24-word phrase
+ *
+ * Returns an object with:
+ *    .privateKey (string) the hex private key
+ *    .address (string) the address of the private key
+ */
+export async function getPaymentKeyInfo24(network: CLINetworkAdapter, mnemonic : string): Promise<PaymentKeyInfoType> {
+  const seed = await bip39.mnemonicToSeed(mnemonic)
+  const master = bip32.fromSeed(seed)
+  const child = master.derivePath(`m/44'/5757'/0'/0/0`)
+  const ecPair = bitcoin.ECPair.fromPrivateKey(child.privateKey)
+  const privkey = blockstack.ecPairToHexString(ecPair)
+  
+  const addr = getPrivateKeyAddress(network, privkey);
+  const result: PaymentKeyInfoType = {
+    privateKey: privkey,
+    address: {
+      BTC: addr,
+      STACKS: c32check.b58ToC32(addr)
+    },
+    index: 0
+  };
+  return result;
+}
+
+/*
  * Find the index of an ID address, given the mnemonic.
  * Returns the index if found
  * Returns -1 if not found


### PR DESCRIPTION
#32 
Solve this problem.

Following is the terminal test log:

```
Gavin@tyGavindeMacintosh ~/workspace/cli-blockstack$ node cmd/index.js get_payment_key_24 "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"
(node:13726) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:13726) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
[
  {
    "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",
    "address": {
      "BTC": "1ATAW6TAbTCKgU3xPgAcWQwjW9Q26Eambx",
      "STACKS": "SP1KTQR7CTQNA20SV2VNTF9YABMR6RJERSES3KC6Z"
    },
    "index": 0
  }
]
```

An suggestion is: the *get_payment_key* method call the *wallet* module in *blockstack.js* repo. I think the best way to add *get_payment_key_24* should be modify some codes in *blockstack.js*'s *wallet* module. 



[blockstack.js/src/wallet.ts](https://github.com/blockstack/blockstack.js/blob/master/src/wallet.ts)
```
export class BlockstackWallet {
  rootNode: BIP32Interface

  constructor(rootNode: BIP32Interface) {
    this.rootNode = rootNode
  }
......
getBitcoinPrivateKeychain(): BIP32Interface {
    return this.rootNode
      .deriveHardened(BITCOIN_BIP_44_PURPOSE)
      .deriveHardened(BITCOIN_COIN_TYPE)
      .deriveHardened(BITCOIN_ACCOUNT_INDEX)
  }
```

But in wallet.ts, the BITCOIN_COIN_TYPE is different from stack_wallet. Here are the codes from blockstack.js and stack_wallet.

[blockstack.js/src/wallet.ts](https://github.com/blockstack/blockstack.js/blob/master/src/wallet.ts)
```
const BITCOIN_BIP_44_PURPOSE = 44
const BITCOIN_COIN_TYPE = 0
const BITCOIN_ACCOUNT_INDEX = 0
```

[stack-wallet](https://github.com/blockstack/stacks-wallet/blob/master/app/common/constants.js)
```
const PATH = `m/44'/5757'/0'/0/0`;
```

In stack-wallet the cointype shows 5757, but in blockstack.js it shows 0. So if unite the two coin-type i believe it will be very simple to solve this problem.

I will create an  issue in stack-wallet and blockstack.js about the coin-type
