### PR TITLE
Adds ability to pass arguments for RPC auth

### DIFF
--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -74,7 +74,9 @@ export interface CLI_CONFIG_TYPE {
   blockstackNodeUrl: string,
   broadcastServiceUrl: string,
   utxoServiceUrl: string,
-  logConfig: CLI_LOG_CONFIG_TYPE
+  logConfig: CLI_LOG_CONFIG_TYPE,
+  bitcoindUsername?: string,
+  bitcoindPassword?: string,
 };
 
 const LOG_CONFIG_DEFAULTS : CLI_LOG_CONFIG_TYPE = {
@@ -99,7 +101,9 @@ const CONFIG_REGTEST_DEFAULTS : CLI_CONFIG_TYPE = {
   blockstackNodeUrl: 'http://localhost:16264',
   broadcastServiceUrl: 'http://localhost:16269',
   utxoServiceUrl: 'http://localhost:18332',
-  logConfig: LOG_CONFIG_DEFAULTS
+  logConfig: LOG_CONFIG_DEFAULTS,
+  bitcoindPassword: 'blockstacksystem',
+  bitcoindUsername: 'blockstack'
 };
 
 const PUBLIC_TESTNET_HOST = 'testnet.blockstack.org';
@@ -2341,7 +2345,7 @@ export const CLI_ARGS = {
           type: 'string',
           realtype: 'private_key',
           pattern: `${PRIVATE_KEY_PATTERN}`
-        },
+        }
       ],
       minItems: 3,
       maxItems: 3,
@@ -2436,6 +2440,10 @@ Options can be:
     -T URL              Use an alternative Blockstack transaction broadcaster.
     
     -X URL              Use an alternative UTXO service endpoint.
+
+    -u USERNAME         A username to be passed to bitcoind RPC endpoints
+
+    -p PASSWORD         A password to be passed to bitcoind RPC endpoints
 `;
 
 /*
@@ -2715,7 +2723,7 @@ interface CLI_OPTS {
 };
 
 export function getCLIOpts(argv: string[],
-  opts: string = 'deitUxC:F:B:P:D:G:N:H:T:I:m:M:X:') : CLI_OPTS {
+  opts: string = 'deitUxC:F:B:P:D:G:N:H:T:I:m:M:X:u:p:') : CLI_OPTS {
   const optsTable : CLI_OPTS = {};
   const remainingArgv = [];
   const argvBuff = argv.slice(0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import * as bip39 from 'bip39';
 import * as express from 'express';
 import * as path from 'path';
 import fetch from 'node-fetch';
-import { makeSTXTokenTransfer, TransactionVersion } from '@blockstack/stacks-transactions'
+import { makeSTXTokenTransfer, TransactionVersion } from '@blockstack/stacks-transactions';
 
 const c32check = require('c32check');
 
@@ -105,6 +105,7 @@ import {
   handleAuth,
   handleSignIn
 } from './auth';
+import { TokenTransferOptions } from '@blockstack/stacks-transactions/lib/src/builders';
 
 // global CLI options
 let txOnly = false;
@@ -1812,18 +1813,18 @@ function register(network: CLINetworkAdapter, args: string[]) : Promise<string> 
     .then(([preorderSafetyChecks, registerSafetyChecks]) => {
       if (!checkTxStatus(preorderSafetyChecks) || !checkTxStatus(registerSafetyChecks)) {
         try {
-           preorderSafetyChecks = JSON.parse(preorderSafetyChecks);
+          preorderSafetyChecks = JSON.parse(preorderSafetyChecks);
         }
         catch (e) {
         }
 
         try {
-           registerSafetyChecks = JSON.parse(registerSafetyChecks);
+          registerSafetyChecks = JSON.parse(registerSafetyChecks);
         }
         catch (e) {
         }
 
-      // one or both safety checks failed 
+        // one or both safety checks failed 
         throw new SafetyError({
           'status': false,
           'error': 'Failed to generate one or more transactions',
@@ -2403,7 +2404,7 @@ function balance(network: CLINetworkAdapter, args: string[]) : Promise<string> {
   return fetch(`${network.blockstackAPIUrl}/v2/accounts/${address}?proof=0`)
     .then((response) => response.json())
     .then((response) => {
-      var balanceHex = response.balance;
+      let balanceHex = response.balance;
       if(balanceHex.startsWith('0x')) {
         balanceHex = balanceHex.substr(2);
       }
@@ -2411,7 +2412,7 @@ function balance(network: CLINetworkAdapter, args: string[]) : Promise<string> {
       const res = {
         balance: balance.toString(10),
         nonce: response.nonce
-      }
+      };
       return Promise.resolve(JSONStringify(res));
     });
 }
@@ -2568,12 +2569,12 @@ function sendTokens(network: CLINetworkAdapter, args: string[]) : Promise<string
     memo = args[5];
   }
 
-  const options = {
+  const options: TokenTransferOptions = {
     nonce,
     memo,
     version: network.isMainnet() ? TransactionVersion.Mainnet : TransactionVersion.Testnet,
     chainId: TransactionVersion.Testnet ? 0x80000000 : 0x00000000
-  }
+  };
 
   const tx = makeSTXTokenTransfer(recipientAddress, tokenAmount, feeRate, privateKey, options);
 
@@ -2634,8 +2635,8 @@ function getKeyAddress(network: CLINetworkAdapter, args: string[]) : Promise<str
 function getDidConfiguration(network: CLINetworkAdapter, args: string[]) : Promise<string> {
   const privateKey = decodePrivateKey(args[2]);
   return makeDIDConfiguration(network, args[0], args[1], args[2]).then(didConfiguration => {
-    return JSONStringify(didConfiguration)
-  })
+    return JSONStringify(didConfiguration);
+  });
 }
 
 /*
@@ -3426,6 +3427,8 @@ export function CLIMain() {
     defaultV2BroadcastUrl = opts['T'] ? CLIOptAsString(opts, 'T') : defaultV2BroadcastUrl;
     const nodeAPIUrl = CLIOptAsString(opts, 'I');
     const utxoUrl = CLIOptAsString(opts, 'X');
+    const bitcoindUsername = CLIOptAsString(opts, 'u');
+    const bitcoindPassword = CLIOptAsString(opts, 'p');
 
     if (integration_test) {
       BLOCKSTACK_TEST = integration_test;
@@ -3449,9 +3452,15 @@ export function CLIMain() {
     else {
       configData.logConfig.level = 'info';
     }
+    if (bitcoindUsername) {
+      configData.bitcoindUsername = bitcoindUsername;
+    }
+    if (bitcoindPassword) {
+      configData.bitcoindPassword = bitcoindPassword;
+    }
 
     if (utxoUrl) {
-       configData.utxoServiceUrl = utxoUrl;
+      configData.utxoServiceUrl = utxoUrl;
     }
 
     winston.configure({ level: configData.logConfig.level, transports: [new winston.transports.Console(configData.logConfig)] });
@@ -3468,7 +3477,7 @@ export function CLIMain() {
       altTransactionBroadcasterUrl: (transactionBroadcasterUrl ? 
         transactionBroadcasterUrl : 
         configData.broadcastServiceUrl),
-      nodeAPIUrl: (nodeAPIUrl ? nodeAPIUrl : configData.blockstackNodeUrl),
+      nodeAPIUrl: (nodeAPIUrl ? nodeAPIUrl : configData.blockstackNodeUrl)
     };
 
     // wrap command-line options

--- a/src/network.ts
+++ b/src/network.ts
@@ -308,7 +308,7 @@ export function getNetwork(configData: CLI_CONFIG_TYPE, regTest: boolean) : Bloc
     const network = new blockstack.network.LocalRegtest(
       configData.blockstackAPIUrl, configData.broadcastServiceUrl, 
       new blockstack.network.BitcoindAPI(configData.utxoServiceUrl,
-        { username: 'blockstack', password: 'blockstacksystem' }));
+        { username: configData.bitcoindUsername || 'blockstack', password: configData.bitcoindPassword || 'blockstacksystem' }));
 
     return network;
   } else {


### PR DESCRIPTION
We had hard-coded bitcoind RPC authentication. We need to make this customizable, to work with other nodes. This adds `-u` and `-p` for bitcoind RPC auth.

Also includes some eslint fixes that were automatically made by my editor.